### PR TITLE
35 redo exports so path imports are not needed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export {Client} from "./Client";
 export type {IClient} from "./IClient";
-export * as Rest from "./rest";
-export * as Objects from "./objects";
-export * as Managers from "./managers";
+export * from "./rest";
+export * from "./objects";
+export * from "./managers";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export {Client} from "./Client";
 export type {IClient} from "./IClient";
+export * as Rest from "./rest";
+export * as Objects from "./objects";
+export * as Managers from "./managers";

--- a/src/managers/index.ts
+++ b/src/managers/index.ts
@@ -1,3 +1,6 @@
 export * from "./interfaces"
+
 export * from "./CardsManager"
 export * from "./UserManger"
+export * from "./UserCardsManager"
+export * from "./DeckManager"

--- a/src/objects/Card.ts
+++ b/src/objects/Card.ts
@@ -1,4 +1,4 @@
-import { ICardVisitor } from "./visitor/ICardVisitor";
+import { ICardVisitor } from "./visitor";
 import { ICard, ICardCritter, ICardItem } from "./interfaces";
 import { Card as CardPayload, CardCritter as CritterPayload, CardItem as ItemPayload } from "../rest/payloads/cards";
 

--- a/src/objects/Card.ts
+++ b/src/objects/Card.ts
@@ -1,4 +1,4 @@
-import { ICardVisitor } from "../visitor/ICardVisitor";
+import { ICardVisitor } from "./visitor/ICardVisitor";
 import { ICard, ICardCritter, ICardItem } from "./interfaces";
 import { Card as CardPayload, CardCritter as CritterPayload, CardItem as ItemPayload } from "../rest/payloads/cards";
 

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -1,1 +1,4 @@
 export * from "./interfaces"
+
+export * from "./Card"
+export * from "./User"

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -1,4 +1,5 @@
 export * from "./interfaces"
+export * from "./visitor"
 
 export * from "./Card"
 export * from "./User"

--- a/src/objects/interfaces/ICard.ts
+++ b/src/objects/interfaces/ICard.ts
@@ -3,7 +3,7 @@
  * @Brief this file contains interfaces for handling both critter and item cards. 
  */
 
-import { ICardVisitor } from "../../visitor/ICardVisitor";
+import { ICardVisitor } from "../visitor/ICardVisitor";
 import { Card as CardPayload } from "../../rest/payloads/cards";
 
 export interface ICard {

--- a/src/objects/interfaces/ICard.ts
+++ b/src/objects/interfaces/ICard.ts
@@ -3,8 +3,7 @@
  * @Brief this file contains interfaces for handling both critter and item cards. 
  */
 
-import { ICardVisitor } from "../visitor/ICardVisitor";
-import { Card as CardPayload } from "../../rest/payloads/cards";
+import { ICardVisitor } from "../visitor";
 
 export interface ICard {
   cardid: number;

--- a/src/objects/visitor/ICardVisitor.ts
+++ b/src/objects/visitor/ICardVisitor.ts
@@ -3,7 +3,7 @@
  * @Brief Generic visitor class for item objects.
  */
 
-import { ICardCritter, ICardItem } from "../objects";
+import { ICardCritter, ICardItem } from "../index";
 
 export interface ICardVisitor {
   visitCritter(critter: ICardCritter): void;

--- a/src/objects/visitor/index.ts
+++ b/src/objects/visitor/index.ts
@@ -1,0 +1,1 @@
+export * from "./ICardVisitor"


### PR DESCRIPTION
this will allow imports like `import {ICardVisitor} from "combatcritters-ts"`

closes #35 